### PR TITLE
Change deprecated method on property

### DIFF
--- a/src/bledom/device.py
+++ b/src/bledom/device.py
@@ -57,7 +57,7 @@ class BleLedDevice:
         """
 
         characteristics = []
-        for service in await bt_client.get_services():
+        for service in bt_client.services:
             for characteristic in service.characteristics:
                 if characteristic.uuid == BLEDOM_CHARACTERISTIC:
                     characteristics.append(characteristic)


### PR DESCRIPTION
Get all services registered for this GATT server.

Deprecated since version 0.17.0: This method will be removed in a future version of Bleak. Use the [services](https://bleak.readthedocs.io/en/latest/api/client.html#bleak.BleakClient.services) property instead.